### PR TITLE
Add survey ID determination for invalid survey, add get_summary()

### DIFF
--- a/limesurveyrc2api/_token.py
+++ b/limesurveyrc2api/_token.py
@@ -7,6 +7,27 @@ class _Token(object):
     def __init__(self, api):
         self.api = api
 
+    def get_summary(self, survey_id):
+        """
+        Get participant properties of a survey.
+
+        Parameters
+        :param survey_id: ID of survey
+        :type survey_id: Integer
+
+        :return: dict with keys 'token_count', 'token_invalid', 'token_sent',
+            'token_opted_out', and 'token_completed' with strings as values.
+        """
+        method = "get_summary"
+        params = OrderedDict([
+            ('sSessionKey', self.api.session_key),
+            ('iSurveyID', survey_id)
+        ])
+        response = self.api.query(method=method, params=params)
+        if type(response) is dict and "status" in response:
+            raise LimeSurveyError(method, response["status"])
+        return response
+
     def add_participants(
             self, survey_id, participant_data, create_token_key=True):
         """
@@ -234,9 +255,5 @@ class _Token(object):
         return response
 
     def remind_participants(self):
-        # TODO
-        raise NotImplementedError
-
-    def get_summary(self):
         # TODO
         raise NotImplementedError

--- a/tests/test__survey.py
+++ b/tests/test__survey.py
@@ -30,7 +30,7 @@ class TestSurveys(TestBase):
     def test_list_questions_failure(self):
         """Listing questions for an invalid survey should returns an error."""
         surveys = self.api.survey.list_surveys()
-        survey_id = surveys[0].get('sid') + 9
+        survey_id = TestBase.get_invalid_survey_id(surveys)
 
         with self.assertRaises(LimeSurveyError) as ctx:
             self.api.survey.list_questions(survey_id)

--- a/tests/test__token.py
+++ b/tests/test__token.py
@@ -11,6 +11,7 @@ class TestTokens(TestBase):
 
         surveys = self.api.survey.list_surveys()
         self.survey_id = surveys[0].get('sid')
+        self.survey_id_invalid = TestBase.get_invalid_survey_id(surveys)
         self.participants = [
             {'email': 't1@example.com', 'lastname': 'LN1', 'firstname': 'FN1'},
             {'email': 't2@example.com', 'lastname': 'LN2', 'firstname': 'FN2'},
@@ -44,7 +45,7 @@ class TestTokens(TestBase):
 
     def test_add_participants_survey_failure(self):
         """Adding participants to an invalid survey should return an error."""
-        survey_id = self.survey_id + 9
+        survey_id = self.survey_id_invalid
 
         with self.assertRaises(LimeSurveyError) as ctx:
             self.api.token.add_participants(

--- a/tests/test__token.py
+++ b/tests/test__token.py
@@ -242,11 +242,12 @@ class TestTokens(TestBase):
         """Query for all participants should return added token ids."""
         added_tokens = self.api.token.add_participants(
             survey_id=self.survey_id, participant_data=self.participants)
-        self.token_ids = [int(x["tid"]) for x in added_tokens]
+        added_token_ids = [x["tid"] for x in added_tokens]
 
         result = self.api.token.list_participants(survey_id=self.survey_id)
         result_token_ids = [x["tid"] for x in result]
-        self.assertListEqual(self.token_ids, result_token_ids)
+        for token_id in added_token_ids:
+            self.assertIn(token_id, result_token_ids)
 
     def test_list_participants_conditions_failure(self):
         """Querying with a condition matching none should result in an error."""

--- a/tests/test__token.py
+++ b/tests/test__token.py
@@ -30,6 +30,33 @@ class TestTokens(TestBase):
             pass  # Passing None for tokens param -> empty list -> assert error.
         super().tearDown()
 
+    def test_get_summary(self):
+        """
+        Get summary of a survey
+        """
+        surveys = self.api.survey.list_surveys()
+        survey_id = surveys[0].get('sid')
+        survey_summary = self.api.token.get_summary(survey_id)
+        # example response:
+        # {'token_count': '26', 'token_invalid': '0', 'token_sent': '0',
+        #  'token_opted_out': '0', 'token_completed': '0'}
+        self.assertIn('token_count', survey_summary)
+        self.assertIsInstance(survey_summary['token_count'], str)
+        self.assertIn('token_invalid', survey_summary)
+        self.assertIsInstance(survey_summary['token_invalid'], str)
+        self.assertIn('token_sent', survey_summary)
+        self.assertIsInstance(survey_summary['token_sent'], str)
+        self.assertIn('token_opted_out', survey_summary)
+        self.assertIsInstance(survey_summary['token_opted_out'], str)
+        self.assertIn('token_completed', survey_summary)
+        self.assertIsInstance(survey_summary['token_completed'], str)
+
+        # error cases
+        # invalid summary
+        with self.assertRaises(LimeSurveyError) as ctx:
+            self.api.token.get_summary(TestBase.get_invalid_survey_id(surveys))
+        self.assertIn('Invalid surveyid', ctx.exception.message)
+
     def test_add_participants_success(self):
         """Adding participants to a survey should return their tokens."""
         added_tokens = self.api.token.add_participants(

--- a/tests/test_limesurvey.py
+++ b/tests/test_limesurvey.py
@@ -32,6 +32,20 @@ class TestBase(unittest.TestCase):
         except LimeSurveyError:
             pass
 
+    @staticmethod
+    def get_invalid_survey_id(surveys):
+        """
+        Determine a survey ID that does not exist in the list of surveys.
+
+        :param surveys: existing surveys
+        :type surveys: List[Dict]
+        :return: invalid survey ID
+        """
+        survey_ids = [s.get('sid') for s in surveys]
+        # construct an invalid survey ID by taking the longest ID
+        # (these are strings) and appending a '9'
+        return sorted(survey_ids, key=len)[-1] + '9'
+
 
 class TestSessionsNoSetup(TestBase):
 


### PR DESCRIPTION
Determine an invalid survey ID based on the IDs of existing surveys.